### PR TITLE
JSCO-8: Allow query string param to disable DNS-SRV lookup

### DIFF
--- a/lib/connspec.ts
+++ b/lib/connspec.ts
@@ -36,8 +36,11 @@ export class ConnSpec {
     }
 
     if (parts[2]) {
-      if (parts[2] !== "couchbases") {
-        throw new Error("Invalid connection string; must start with secure scheme \"couchbases://\", but got: " + parts[2])
+      if (parts[2] !== 'couchbases') {
+        throw new Error(
+          'Invalid connection string; must start with secure scheme "couchbases://", but got: ' +
+            parts[2]
+        )
       }
     } else {
       spec.scheme = 'couchbases'
@@ -90,6 +93,12 @@ export class ConnSpec {
       }
     } else {
       spec.options = {}
+    }
+
+    // Columnar allows for an srv=false option, map to C++ core
+    if ('srv' in spec.options) {
+      spec.options.enable_dns_srv = spec.options.srv
+      delete spec.options['srv']
     }
 
     return spec

--- a/test/connspec.test.js
+++ b/test/connspec.test.js
@@ -112,5 +112,15 @@ describe('#ConnSpec', function () {
         options: {},
       })
     })
+
+    it('should parse a query string and disable dns srv', function () {
+      var x = ConnSpec.parse('couchbases://localhost?srv=false')
+      assert.deepEqual(x, {
+        scheme: 'couchbases',
+        hosts: [['localhost', 0]],
+        bucket: '',
+        options: { enable_dns_srv: 'false' },
+      })
+    })
   })
 })


### PR DESCRIPTION
Changes
=======
* Update query string parsing to handle srv query string param
* Add test to confirm functionality