### PR TITLE
JSCO-9: Validate Cancel API

### DIFF
--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -39,7 +39,7 @@ export interface CppDnsConfig {
 
 export interface CppColumnarQueryResult {
   nextRow(callback: (row: string, err: CppColumnarError | null) => void): void
-  cancel(): void
+  cancel(): boolean
   metadata(): CppColumnarQueryMetadata | undefined
 }
 
@@ -150,11 +150,11 @@ export interface CppConnection extends CppConnectionAutogen {
 
   query(
     options: CppColumnarQueryOptions,
-    callback: (
-      result: CppColumnarQueryResult,
-      err: CppColumnarError | null
-    ) => void
-  ): void
+    callback: (err: CppColumnarError | null) => void
+  ): {
+    cppQueryErr: CppColumnarError | null
+    cppQueryResult: CppColumnarQueryResult
+  }
 }
 
 export interface CppBinding extends CppBindingAutogen {

--- a/lib/bindingutilities.ts
+++ b/lib/bindingutilities.ts
@@ -53,3 +53,15 @@ export function errorFromCpp(err: CppColumnarError | null): Error | null {
       return new errs.ColumnarError(err.message_and_ctx)
   }
 }
+
+/**
+ * @internal
+ */
+export function errorFromCanceledOp(err: errs.ColumnarError | null): boolean {
+  if (!err) {
+    return false
+  }
+  return (
+    err.message.includes('query operation') && err.message.includes('canceled')
+  )
+}

--- a/lib/cluster.ts
+++ b/lib/cluster.ts
@@ -327,7 +327,7 @@ export class Cluster {
       options = {}
     }
 
-    const exec = new QueryExecutor(this)
+    const exec = new QueryExecutor(this, options.abortSignal)
     return exec.query(statement, options)
   }
 
@@ -394,8 +394,11 @@ export class Cluster {
         // TODO: log warning?
         securityOpts.trustOnlyCapella = true
       }
-      if (typeof this._securityOptions.verifyServerCertificates === 'boolean' && !this._securityOptions.verifyServerCertificates) {
-        dsnObj.options['tls_verify'] = "none"
+      if (
+        typeof this._securityOptions.verifyServerCertificates === 'boolean' &&
+        !this._securityOptions.verifyServerCertificates
+      ) {
+        dsnObj.options['tls_verify'] = 'none'
       }
     } else {
       securityOpts.trustOnlyCapella = true

--- a/lib/scope.ts
+++ b/lib/scope.ts
@@ -63,6 +63,7 @@ export class Scope {
 
     const exec = new QueryExecutor(
       this.cluster,
+      options.abortSignal,
       this._database.name,
       this._name
     )

--- a/src/query_result.hpp
+++ b/src/query_result.hpp
@@ -3,6 +3,7 @@
 #include "addondata.hpp"
 #include "napi.h"
 #include <core/columnar/query_result.hxx>
+#include <core/pending_operation.hxx>
 
 namespace couchnode
 {
@@ -19,11 +20,15 @@ public:
   QueryResult(const Napi::CallbackInfo& info);
   ~QueryResult();
 
+  void setPendingOp(std::shared_ptr<couchbase::core::pending_operation> pending_op);
+  void setQueryResult(couchbase::core::columnar::query_result query_result);
+
   Napi::Value jsNextRow(const Napi::CallbackInfo& info);
   Napi::Value jsCancel(const Napi::CallbackInfo& info);
   Napi::Value jsMetadata(const Napi::CallbackInfo& info);
 
 private:
+  std::shared_ptr<couchbase::core::pending_operation> pending_op_;
   std::shared_ptr<couchbase::core::columnar::query_result> result_;
 };
 } // namespace couchnode

--- a/test/harness.js
+++ b/test/harness.js
@@ -48,6 +48,7 @@ var TEST_CONFIG = {
   version: new ServerVersion(0, 0, 0),
   database: 'Default',
   scope: 'Default',
+  collection: 'Default',
   user: undefined,
   pass: undefined,
   features: [],
@@ -69,6 +70,9 @@ if (process.env.NCBCCDATABASE !== undefined) {
 }
 if (process.env.NCBCCSCOPE !== undefined) {
   TEST_CONFIG.scope = process.env.NCBCCSCOPE
+}
+if (process.env.NCBCCCOLLECTION !== undefined) {
+  TEST_CONFIG.collection = process.env.NCBCCCOLLECTION
 }
 if (process.env.NCBCCUSER !== undefined) {
   TEST_CONFIG.user = process.env.NCBCCUSER
@@ -105,6 +109,7 @@ class Harness {
     this._version = TEST_CONFIG.version
     this._database = TEST_CONFIG.database
     this._scope = TEST_CONFIG.scope
+    this._collection = TEST_CONFIG.collection
     this._user = TEST_CONFIG.user
     this._pass = TEST_CONFIG.pass
     this._integrationEnabled = true
@@ -134,6 +139,14 @@ class Harness {
 
   get scopeName() {
     return this._scope
+  }
+
+  get collectionName() {
+    return this._collection
+  }
+
+  get fqdn() {
+    return `\`${this._database}\`.\`${this._scope}\`.\`${this._collection}\``
   }
 
   get integrationEnabled() {
@@ -187,7 +200,7 @@ class Harness {
   async maybeCreateScope(scope) {
     try {
       await this.maybeCreateDatabase(scope.database)
-      const qs = `CREATE SCOPE ${scope.database.name}.${scope.name} IF NOT EXISTS`
+      const qs = `CREATE SCOPE \`${scope.database.name}\`.\`${scope.name}\` IF NOT EXISTS`
       await scope.database.cluster.executeQuery(qs)
     } catch (e) {
       console.warn('Failed maybe creating scope/database: ' + e)
@@ -196,7 +209,7 @@ class Harness {
 
   async maybeCreateDatabase(database) {
     if (database.name !== 'Default') {
-      const qs = `CREATE DATABASE ${database.name} IF NOT EXISTS`
+      const qs = `CREATE DATABASE \`${database.name}\` IF NOT EXISTS`
       await database.cluster.executeQuery(qs)
     }
   }

--- a/test/query.test.js
+++ b/test/query.test.js
@@ -1,139 +1,311 @@
 'use strict'
 
+const { setTimeout } = require('node:timers/promises')
+
 const assert = require('chai').assert
 const H = require('./harness')
 
-const { QueryScanConsistency } = require('../lib/querytypes')
+const {
+  QueryMetadata,
+  QueryMetrics,
+  QueryResult,
+  QueryScanConsistency,
+} = require('../lib/querytypes')
+const { Cluster } = require('../lib/cluster')
 const {
   PassthroughDeserializer,
   JsonDeserializer,
 } = require('../lib/deserializers')
 
-describe('#columnar', function () {
-  before(async function () {
-    H.skipIfIntegrationDisabled(this)
-  })
-
-  it('should successfully stream rows with cluster query', async function () {
-    let results = []
-    const qs = `FROM RANGE(1, 100) AS i SELECT *`
-    let res = await H.c.executeQuery(qs)
-    for await (const row of res.rows()) {
-      results.push(row)
-    }
-    assert.equal(results.length, 100)
-  })
-
-  it('should use the passthrough deserializer', async function () {
-    let jsonRows = []
-    let passthroughRows = []
-
-    const qs = `SELECT 1=1`
-    let jsonRes = await H.c.executeQuery(qs, {
-      deserializer: new JsonDeserializer(),
-    })
-    let passthroughRes = await H.c.executeQuery(qs, {
-      deserializer: new PassthroughDeserializer(),
-    })
-    for await (const row of jsonRes.rows()) {
-      jsonRows.push(row)
-    }
-    for await (const row of passthroughRes.rows()) {
-      passthroughRows.push(row)
-    }
-
-    assert.equal(jsonRows.length, 1)
-    assert.equal(passthroughRows.length, 1)
-    assert.isObject(jsonRows.at(0))
-    assert.isString(passthroughRows.at(0))
-  })
-
-  it('should successfully stream rows with scope query', async function () {
-    let results = []
-    const qs = `FROM RANGE(1, 100) AS i SELECT *`
-    let res = await H.s.executeQuery(qs)
-    for await (const row of res.rows()) {
-      results.push(row)
-    }
-    assert.equal(results.length, 100)
-  })
-
-  it('should work with multiple options', async function () {
-    const results = []
-    const qs = `SELECT $five=5`
-
-    let res = await H.c.executeQuery(qs, {
-      namedParameters: {
-        five: 5,
-      },
-      readOnly: true,
-      scanConsistency: QueryScanConsistency.NotBounded,
-      priority: true,
+function genericTests(instance) {
+  describe('#queryTests', function () {
+    before(async function () {
+      H.skipIfIntegrationDisabled(this)
     })
 
-    for await (const row of res.rows()) {
-      results.push(row)
-    }
-
-    assert.equal(results.length, 1)
-    assert.isTrue(results.at(0)['$1'])
-  })
-
-  it('should work with positional parameters', async function () {
-    const results = []
-    const qs = `SELECT $2=1`
-
-    let res = await H.c.executeQuery(qs, {
-      positionalParameters: [undefined, 1],
+    it('should successfully stream rows', async function () {
+      let results = []
+      const qs = `FROM RANGE(1, 100) AS i SELECT *`
+      let res = await instance().executeQuery(qs)
+      for await (const row of res.rows()) {
+        results.push(row)
+      }
+      assert.equal(results.length, 100)
     })
 
-    for await (const row of res.rows()) {
-      results.push(row)
-    }
+    it('should successfully stream rows using events', async function () {
+      const eventStreamQuery = (qRes) => {
+        return new Promise((resolve, reject) => {
+          const results = []
+          const readable = qRes.rows()
+          readable.on('data', (row) => {
+            results.push(row)
+          })
+          readable.on('end', () => {
+            const metadata = qRes.metadata()
+            resolve({
+              rows: results,
+              meta: metadata,
+            })
+          })
+          readable.on('error', (err) => {
+            reject(err)
+          })
+        })
+      }
 
-    assert.equal(results.length, 1)
-    assert.isTrue(results.at(0)['$1'])
-  })
-
-  it('should fetch all databases', async function () {
-    const results = []
-    const qs = `SELECT RAW {\`DatabaseName\`, \`SystemDatabase\`}
-        FROM \`System\`.\`Metadata\`.\`Database\``
-
-    let res = await H.c.executeQuery(qs)
-
-    for await (const row of res.rows()) {
-      results.push(row)
-    }
-
-    assert.isAtLeast(results.length, 2)
-
-    const testDatabase = results.find((db) => db.DatabaseName === H.d.name)
-    const systemDatabase = results.find((db) => db.DatabaseName === 'System')
-
-    assert.isNotNull(systemDatabase)
-    assert.isNotNull(testDatabase)
-    assert.isTrue(systemDatabase['SystemDatabase'])
-    assert.isFalse(testDatabase['SystemDatabase'])
-  })
-
-  it('should fetch all scopes', async function () {
-    const results = []
-    const qs = `SELECT RAW \`DataverseName\`
-        FROM \`System\`.\`Metadata\`.\`Dataverse\`
-        WHERE \`DatabaseName\` = ?`
-
-    let res = await H.c.executeQuery(qs, {
-      positionalParameters: [H.d.name],
+      const qs = `FROM RANGE(1, 100) AS i SELECT *`
+      let qRes = await instance().executeQuery(qs)
+      let result
+      try {
+        result = await eventStreamQuery(qRes)
+      } catch (err) {} // eslint-disable-line no-empty
+      assert.equal(result.rows.length, 100)
+      assert.instanceOf(result.meta, QueryMetadata)
     })
 
-    for await (const row of res.rows()) {
-      results.push(row)
-    }
+    it('should use the passthrough deserializer', async function () {
+      let jsonRows = []
+      let passthroughRows = []
 
-    const testScope = results.find((scope) => scope === H.s.name)
+      const qs = `SELECT 1=1`
+      let jsonRes = await instance().executeQuery(qs, {
+        deserializer: new JsonDeserializer(),
+      })
+      let passthroughRes = await instance().executeQuery(qs, {
+        deserializer: new PassthroughDeserializer(),
+      })
+      for await (const row of jsonRes.rows()) {
+        jsonRows.push(row)
+      }
+      for await (const row of passthroughRes.rows()) {
+        passthroughRows.push(row)
+      }
 
-    assert.isNotNull(testScope)
-    assert.isAtLeast(results.length, 1)
+      assert.equal(jsonRows.length, 1)
+      assert.equal(passthroughRows.length, 1)
+      assert.isObject(jsonRows.at(0))
+      assert.isString(passthroughRows.at(0))
+    })
+
+    it('should work with multiple options', async function () {
+      const results = []
+      const qs = `SELECT $five=5`
+
+      let res = await instance().executeQuery(qs, {
+        namedParameters: {
+          five: 5,
+        },
+        readOnly: true,
+        scanConsistency: QueryScanConsistency.NotBounded,
+        priority: true,
+      })
+
+      for await (const row of res.rows()) {
+        results.push(row)
+      }
+
+      assert.equal(results.length, 1)
+      assert.isTrue(results.at(0)['$1'])
+    })
+
+    it('should work with positional parameters', async function () {
+      const results = []
+      const qs = `SELECT $2=1`
+
+      let res = await instance().executeQuery(qs, {
+        positionalParameters: [undefined, 1],
+      })
+
+      for await (const row of res.rows()) {
+        results.push(row)
+      }
+
+      assert.equal(results.length, 1)
+      assert.isTrue(results.at(0)['$1'])
+    })
+
+    it('should successfully provide query metadata', async function () {
+      let results = []
+      const qs = `FROM RANGE(1, 100) AS i SELECT *`
+      let res = await instance().executeQuery(qs)
+      for await (const row of res.rows()) {
+        results.push(row)
+      }
+      assert.equal(results.length, 100)
+
+      const metadata = res.metadata()
+      assert.instanceOf(metadata, QueryMetadata)
+      assert.notStrictEqual(metadata.requestId, '')
+      assert.isArray(metadata.warnings)
+      assert.equal(metadata.warnings.length, 0)
+      const metrics = metadata.metrics
+      assert.instanceOf(metrics, QueryMetrics)
+      assert.isAbove(metrics.resultSize, 0)
+      assert.equal(metrics.resultCount, 100)
+      assert.isAtLeast(metrics.processedObjects, 0)
+      assert.isAbove(metrics.elapsedTime, 0)
+      assert.isAbove(metrics.executionTime, 0)
+    })
+
+    it('should raise Error when query metadata is unavailable', async function () {
+      let results = []
+      const qs = `FROM RANGE(1, 100) AS i SELECT *`
+      let res = await instance().executeQuery(qs)
+      try {
+        res.metadata()
+      } catch (err) {
+        assert.equal(
+          err.message,
+          'Metadata is only available once all rows have been iterated'
+        )
+      }
+
+      // read one row
+      for await (const row of res.rows().iterator({ destroyOnReturn: false })) {
+        results.push(row)
+        break
+      }
+
+      try {
+        res.metadata()
+      } catch (err) {
+        assert.equal(
+          err.message,
+          'Metadata is only available once all rows have been iterated'
+        )
+      }
+
+      for await (const row of res.rows()) {
+        results.push(row)
+      }
+      assert.equal(results.length, 100)
+
+      // now okay to get metrics
+      const metadata = res.metadata()
+      assert.instanceOf(metadata, QueryMetadata)
+      assert.notStrictEqual(metadata.requestId, '')
+      assert.isArray(metadata.warnings)
+      assert.equal(metadata.warnings.length, 0)
+      const metrics = metadata.metrics
+      assert.instanceOf(metrics, QueryMetrics)
+    })
+
+    it('should fetch all databases', async function () {
+      const results = []
+      const qs = `SELECT RAW {\`DatabaseName\`, \`SystemDatabase\`}
+          FROM \`System\`.\`Metadata\`.\`Database\``
+
+      let res = await instance().executeQuery(qs)
+
+      for await (const row of res.rows()) {
+        results.push(row)
+      }
+
+      assert.isAtLeast(results.length, 2)
+
+      const testDatabase = results.find((db) => db.DatabaseName === H.d.name)
+      const systemDatabase = results.find((db) => db.DatabaseName === 'System')
+
+      assert.isNotNull(systemDatabase)
+      assert.isNotNull(testDatabase)
+      assert.isTrue(systemDatabase['SystemDatabase'])
+      assert.isFalse(testDatabase['SystemDatabase'])
+    })
+
+    it('should fetch all scopes', async function () {
+      const results = []
+      const qs = `SELECT RAW \`DataverseName\`
+          FROM \`System\`.\`Metadata\`.\`Dataverse\`
+          WHERE \`DatabaseName\` = ?`
+
+      let res = await instance().executeQuery(qs, {
+        positionalParameters: [H.d.name],
+      })
+
+      for await (const row of res.rows()) {
+        results.push(row)
+      }
+
+      const testScope = results.find((scope) => scope === H.s.name)
+
+      assert.isNotNull(testScope)
+      assert.isAtLeast(results.length, 1)
+    })
+
+    it('should cancel prior to iterating', async function () {
+      const qs = 'FROM range(0, 1000000) AS r SELECT *'
+      const abortController = new AbortController()
+
+      let qResPromise = instance().executeQuery(qs, {
+        abortSignal: abortController.signal,
+      })
+      assert.instanceOf(qResPromise, Promise)
+      await setTimeout(250).then(() => {
+        abortController.abort()
+      })
+      let res = await qResPromise
+      assert.instanceOf(res, QueryResult)
+      try {
+        res.rows()
+      } catch (err) {
+        assert.strictEqual(err.name, 'AbortError')
+      }
+    })
+
+    it('should cancel while iterating using abort controller', async function () {
+      let from = instance() instanceof Cluster ? H.fqdn : H.collectionName
+      const qs = `SELECT * FROM ${from} LIMIT 10;`
+      const abortController = new AbortController()
+      const results = []
+      const expectedCount = 5
+      let count = 0
+      let res = await instance().executeQuery(qs, {
+        abortSignal: abortController.signal,
+      })
+      try {
+        for await (const row of res.rows()) {
+          if (count == 4) {
+            abortController.abort()
+          }
+          results.push(row)
+          count += 1
+        }
+      } catch (err) {
+        assert.strictEqual(err.name, 'AbortError')
+      }
+      assert.strictEqual(results.length, expectedCount)
+    })
+
+    it('should cancel while iterating using query result cancel', async function () {
+      let from = instance() instanceof Cluster ? H.fqdn : H.collectionName
+      const qs = `SELECT * FROM ${from} LIMIT 10;`
+      const results = []
+      const expectedCount = 5
+      let count = 0
+      let res = await instance().executeQuery(qs)
+      try {
+        for await (const row of res.rows()) {
+          if (count == expectedCount - 1) {
+            res.cancel()
+          }
+          results.push(row)
+          count += 1
+        }
+      } catch (err) {
+        assert.strictEqual(err.name, 'AbortError')
+      }
+      assert.strictEqual(results.length, expectedCount)
+    })
   })
+}
+
+describe('#Columnar query - cluster', function () {
+  /* eslint-disable-next-line mocha/no-setup-in-describe */
+  genericTests(() => H.c)
+})
+
+describe('#Columnar query - scope', function () {
+  /* eslint-disable-next-line mocha/no-setup-in-describe */
+  genericTests(() => H.s)
 })


### PR DESCRIPTION
Motivation
==========
Eventually cancelling certain requests will be part of the provided Columnar API.  We want to make sure we have a good baseline for being able to provide cnacel functionality.

Changes
=======
* Allow cancellation via AbortSignal
* Allow operations to cancel prior to streaming
* Add tests to confirm functionality