### PR TITLE
Add ClusterOptions unit tests and SecurityOptions validation

### DIFF
--- a/lib/cluster.ts
+++ b/lib/cluster.ts
@@ -399,7 +399,19 @@ export class Cluster {
 
     const securityOpts: CppClusterSecurityOptions = {}
     if (this._securityOptions) {
-      // TODO:  validate options??
+      const trustOptionsCount =
+          (this._securityOptions.trustOnlyCapella ? 1 : 0) +
+          (this._securityOptions.trustOnlyPemFile ? 1 : 0) +
+          (this._securityOptions.trustOnlyPemString ? 1 : 0) +
+          (this._securityOptions.trustOnlyPlatform ? 1 : 0) +
+          (this._securityOptions.trustOnlyCertificates ? 1 : 0)
+
+      if (trustOptionsCount > 1) {
+        throw new Error(
+            'Only one of trustOnlyCapella, trustOnlyPemFile, trustOnlyPemString, trustOnlyPlatform, or trustOnlyCertificates can be set.'
+        )
+      }
+
       if (this._securityOptions.trustOnlyCapella) {
         securityOpts.trustOnlyCapella = true
       } else if (this._securityOptions.trustOnlyPemFile) {

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -47,13 +47,9 @@ describe('#Cluster', function () {
     assert.equal(cluster.resolveTimeout, 30000)
   })
 
-  it('should correctly set all security options', function () {
+  it('should correctly set security options', function () {
     let options = {
       securityOptions: {
-        trustOnlyCapella: true,
-        trustOnlyPemFile: "pemFile",
-        trustOnlyPemString: "pemString",
-        trustOnlyCertificates: ["cert1", "cert2"],
         trustOnlyPlatform: true,
         verifyServerCertificates: false,
         cipherSuites: ["suite"]
@@ -66,13 +62,45 @@ describe('#Cluster', function () {
         options
     )
 
-    assert.isTrue(cluster._securityOptions.trustOnlyCapella)
-    assert.strictEqual(cluster._securityOptions.trustOnlyPemFile, "pemFile")
-    assert.strictEqual(cluster._securityOptions.trustOnlyPemString, "pemString")
-    assert.deepEqual(cluster._securityOptions.trustOnlyCertificates, ["cert1", "cert2"])
     assert.isTrue(cluster._securityOptions.trustOnlyPlatform)
     assert.isFalse(cluster._securityOptions.verifyServerCertificates)
     assert.deepEqual(cluster._securityOptions.cipherSuites, ["suite"])
+    assert.isUndefined(cluster._securityOptions.trustOnlyCapella)
+    assert.isUndefined(cluster._securityOptions.trustOnlyPemFile)
+    assert.isUndefined(cluster._securityOptions.trustOnlyCertificates)
+    assert.isUndefined(cluster._securityOptions.trustOnlyPemString)
+  })
+
+  it('should default to trustOnlyCapella if no options are set', function () {
+    const cluster = H.lib.Cluster.createInstance(
+        H.connStr,
+        H.credentials,
+    )
+
+    assert.isTrue(cluster._securityOptions.trustOnlyCapella)
+    assert.isUndefined(cluster._securityOptions.trustOnlyPemFile)
+    assert.isUndefined(cluster._securityOptions.trustOnlyCertificates)
+    assert.isUndefined(cluster._securityOptions.trustOnlyPemString)
+    assert.isUndefined(cluster._securityOptions.trustOnlyPlatform)
+    assert.isUndefined(cluster._securityOptions.verifyServerCertificates)
+    assert.isUndefined(cluster._securityOptions.cipherSuites)
+  })
+
+  it('should throw an error if multiple trustOnly options are set', function () {
+    let options = {
+      securityOptions: {
+        trustOnlyCapella: true,
+        trustOnlyPemFile: "pemFile",
+      }
+    }
+
+    H.throwsHelper(() => {
+      H.lib.Cluster.createInstance(
+          H.connStr,
+          H.credentials,
+          options
+      )
+    }, Error)
   })
 
   it('should correctly set dns options', function () {
@@ -95,7 +123,7 @@ describe('#Cluster', function () {
     assert.strictEqual(cluster._dnsConfig.dnsSrvTimeout, 3000)
   })
 
-  it ('should correctly set cluster-level deserializer', function() {
+  it ('should correctly set cluster-level deserializer', function () {
     let options = {
       deserializer: new PassthroughDeserializer()
     }

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -17,10 +17,10 @@
 
 'use strict'
 
-const assert = require('assert')
-const harness = require('./harness')
+const assert = require('chai').assert
+const H = require('./harness')
 
-const H = harness
+const { PassthroughDeserializer } = require("../lib/deserializers");
 
 describe('#Cluster', function () {
   it('should correctly set timeouts', function () {
@@ -45,6 +45,67 @@ describe('#Cluster', function () {
     assert.equal(cluster.managementTimeout, 80000)
     assert.equal(cluster.queryTimeout, 80000)
     assert.equal(cluster.resolveTimeout, 30000)
+  })
+
+  it('should correctly set all security options', function () {
+    let options = {
+      securityOptions: {
+        trustOnlyCapella: true,
+        trustOnlyPemFile: "pemFile",
+        trustOnlyPemString: "pemString",
+        trustOnlyCertificates: ["cert1", "cert2"],
+        trustOnlyPlatform: true,
+        verifyServerCertificates: false,
+        cipherSuites: ["suite"]
+      }
+    }
+
+    const cluster = H.lib.Cluster.createInstance(
+        H.connStr,
+        H.credentials,
+        options
+    )
+
+    assert.isTrue(cluster._securityOptions.trustOnlyCapella)
+    assert.strictEqual(cluster._securityOptions.trustOnlyPemFile, "pemFile")
+    assert.strictEqual(cluster._securityOptions.trustOnlyPemString, "pemString")
+    assert.deepEqual(cluster._securityOptions.trustOnlyCertificates, ["cert1", "cert2"])
+    assert.isTrue(cluster._securityOptions.trustOnlyPlatform)
+    assert.isFalse(cluster._securityOptions.verifyServerCertificates)
+    assert.deepEqual(cluster._securityOptions.cipherSuites, ["suite"])
+  })
+
+  it('should correctly set dns options', function () {
+    let options = {
+      dnsConfig: {
+        nameserver: "localhost",
+        port: 12345,
+        dnsSrvTimeout: 3000
+      }
+    }
+
+    const cluster = H.lib.Cluster.createInstance(
+        H.connStr,
+        H.credentials,
+        options
+    )
+
+    assert.strictEqual(cluster._dnsConfig.nameserver, "localhost")
+    assert.strictEqual(cluster._dnsConfig.port, 12345)
+    assert.strictEqual(cluster._dnsConfig.dnsSrvTimeout, 3000)
+  })
+
+  it ('should correctly set cluster-level deserializer', function() {
+    let options = {
+      deserializer: new PassthroughDeserializer()
+    }
+
+    const cluster = H.lib.Cluster.createInstance(
+        H.connStr,
+        H.credentials,
+        options
+    )
+    assert.instanceOf(cluster.deserializer, PassthroughDeserializer)
   })
 
   it('should error ops after close and ignore superfluous closes', async function () {


### PR DESCRIPTION
Changes:

- Added securityOption validation, ensuring only one of the `trustOnly` options are set
- Added unit tests