### PR TITLE
JSCO-27: Update ClusterOptions parsing

### DIFF
--- a/lib/binding.ts
+++ b/lib/binding.ts
@@ -45,13 +45,12 @@ export interface CppClusterSecurityOptions {
   trustOnlyPemString?: string
   trustOnlyPlatform?: boolean
   trustOnlyCertificates?: string[]
-  cipherSuites?: string[]
 }
 
 export interface CppDnsConfig {
   nameserver?: string
   port?: number
-  dnsSrvTimeout?: number
+  dnsSrvTimeout?: number | string
 }
 
 export interface CppColumnarQueryResult {

--- a/lib/cluster.ts
+++ b/lib/cluster.ts
@@ -414,7 +414,7 @@ export class Cluster {
     // pass it to the C++ core via the connstr.  Need to use golang syntax for correct parsing.
 
     // Remember the translations in the C++ core:
-    // bootstrapTimeout == columnar connection_timeout (which is bootstrap_timeout in C++ core)
+    // bootstrapTimeout == columnar connect_timeout (which is bootstrap_timeout in C++ core)
     if (
       !('timeout.connect_timeout' in dsnObj.options) &&
       this.bootstrapTimeout

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -86,3 +86,15 @@ export class OperationCanceledError extends Error {
     this.name = this.constructor.name
   }
 }
+
+/**
+ * Indicates that one of the passed arguments was invalid.
+ *
+ * @category Error Handling
+ */
+export class InvalidArgumentError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = this.constructor.name
+  }
+}

--- a/lib/queryexecutor.ts
+++ b/lib/queryexecutor.ts
@@ -171,7 +171,6 @@ export class QueryExecutor {
   query(statement: string, options: QueryOptions): Promise<QueryResult> {
     return new Promise((resolve, reject) => {
       const deserializer = options.deserializer || this._cluster.deserializer
-      const timeout = options.timeout || this._cluster.queryTimeout
 
       const { cppQueryErr, cppQueryResult } = this._cluster.conn.query(
         {
@@ -200,7 +199,7 @@ export class QueryExecutor {
                   .map(([k, v]) => [k, JSON.stringify(v)])
               )
             : {},
-          timeout: timeout,
+          timeout: options.timeout,
         },
         (cppErr) => {
           const err = errorFromCpp(cppErr)

--- a/test/cluster.test.js
+++ b/test/cluster.test.js
@@ -124,7 +124,6 @@ describe('#Cluster', function () {
       securityOptions: {
         trustOnlyPlatform: true,
         verifyServerCertificates: false,
-        cipherSuites: ['suite'],
       },
     }
 
@@ -136,7 +135,6 @@ describe('#Cluster', function () {
 
     assert.isTrue(cluster._securityOptions.trustOnlyPlatform)
     assert.isFalse(cluster._securityOptions.verifyServerCertificates)
-    assert.deepEqual(cluster._securityOptions.cipherSuites, ['suite'])
     assert.isUndefined(cluster._securityOptions.trustOnlyCapella)
     assert.isUndefined(cluster._securityOptions.trustOnlyPemFile)
     assert.isUndefined(cluster._securityOptions.trustOnlyCertificates)
@@ -152,7 +150,6 @@ describe('#Cluster', function () {
     assert.isUndefined(cluster._securityOptions.trustOnlyPemString)
     assert.isUndefined(cluster._securityOptions.trustOnlyPlatform)
     assert.isUndefined(cluster._securityOptions.verifyServerCertificates)
-    assert.isUndefined(cluster._securityOptions.cipherSuites)
   })
 
   it('should throw an error if multiple trustOnly options are set', function () {


### PR DESCRIPTION
Changes
=======
* Update C++ core
* Allow all conn string params to be parsed in C++ core
* Ensure conn string params override options objects
* Update bindings to correctly set core security_options