### PR TITLE
JSCO-61: Columnar - Do not raise OperationCanceledError

### DIFF
--- a/lib/bindingutilities.ts
+++ b/lib/bindingutilities.ts
@@ -52,7 +52,10 @@ export function errorFromCpp(err: CppColumnarError | null): Error | null {
 
   // TODO:  handle other client_errc
   if (err.client_err_code && err.client_err_code === 'canceled') {
-    return new errs.OperationCanceledError(err.message_and_ctx)
+    return new errs.ColumnarError(
+      err.message_and_ctx,
+      new errs.OperationCanceledError(err.message)
+    )
   }
 
   switch (err.code) {

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -22,9 +22,12 @@
  * @category Error Handling
  */
 export class ColumnarError extends Error {
-  constructor(message: string) {
+  cause: Error | undefined
+
+  constructor(message: string, cause?: Error) {
     super(message)
     this.name = this.constructor.name
+    this.cause = cause
   }
 }
 

--- a/lib/queryexecutor.ts
+++ b/lib/queryexecutor.ts
@@ -25,7 +25,6 @@ import {
 import { errorFromCpp, queryScanConsistencyToCpp } from './bindingutilities'
 import { Cluster } from './cluster'
 import { CppColumnarQueryResult, CppColumnarError } from './binding'
-import { OperationCanceledError } from './errors'
 
 /**
  * @internal
@@ -203,7 +202,7 @@ export class QueryExecutor {
         },
         (cppErr) => {
           const err = errorFromCpp(cppErr)
-          if (err && !(err instanceof OperationCanceledError)) {
+          if (err && !this._signal.aborted) {
             reject(err)
             return
           }


### PR DESCRIPTION
Changes
=======
* Wrap OperationCanceledError in ColumnarError when returned from bindings
* Change logic in QueryExecutor.query() to not reject the promise if the bindings return an error AND the query as been aborted (in that instance we want the AbortError, in all other instances we want to raise an error)